### PR TITLE
Performance boost for Process, and small fixes

### DIFF
--- a/concat.go
+++ b/concat.go
@@ -5,7 +5,7 @@ package sequence
 func Concat[T any](seqs ...Sequence[T]) Sequence[T] {
 	return Generate(func(f func(T) error) error {
 		for _, seq := range seqs {
-			if err := Each(seq)(f); err != nil {
+			if err := seq.Each(f); err != nil {
 				return err
 			}
 		}

--- a/concat_test.go
+++ b/concat_test.go
@@ -34,8 +34,8 @@ func TestConcat(t *testing.T) {
 
 func TestFlatten(t *testing.T) {
 	seq := New([]int{1, 2, 3}, []int{6, 5, 4})
-	flat := Flatten(seq)
-	want := []int{1, 2, 3, 6, 5, 4}
+	flat := Flatten(seq).Limit(5)
+	want := []int{1, 2, 3, 6, 5}
 	got, err := flat.ToSlice()
 	if err != nil {
 		t.Errorf("unexpected error upon conversion to slice: %v", err)

--- a/mapfilter_test.go
+++ b/mapfilter_test.go
@@ -1,0 +1,22 @@
+package sequence
+
+import (
+	"testing"
+
+	"github.com/cookieo9/sequence/tools"
+)
+
+func BenchmarkFilter(b *testing.B) {
+	seq := NumberSequence(0, 1_000_000, 1)
+	b.Run("NoFilter", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tools.Check(Each(seq)(func(i int) error { return nil }))
+		}
+	})
+	filtered := seq.Filter(func(i int) bool { return true })
+	b.Run("Filter", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			tools.Check(Each(filtered)(func(i int) error { return nil }))
+		}
+	})
+}

--- a/process.go
+++ b/process.go
@@ -1,6 +1,8 @@
 package sequence
 
 import (
+	"sync/atomic"
+
 	"github.com/cookieo9/sequence/tools"
 )
 
@@ -12,15 +14,24 @@ import (
 // single input value. It can also return an error to stop processing.
 func Process[In, Out any](src Sequence[In], proc func(In, func(Out)) error) Sequence[Out] {
 	return Derive(src, func(f func(Out) error) error {
-		return src.Each(func(i In) error {
-			var err error
-			emit := func(out Out) {
-				if err == nil {
-					err = f(out)
+		var (
+			err atomic.Value
+		)
+
+		emit := func(out Out) {
+			if err.Load() == nil {
+				if e := f(out); e != nil {
+					err.CompareAndSwap(nil, e)
 				}
 			}
+		}
+
+		return src.Each(func(i In) error {
 			e2 := proc(i, emit)
-			return tools.Or(err, e2)
+			if e1 := err.Load(); e1 != nil {
+				return tools.Or(e1.(error), e2)
+			}
+			return e2
 		})
 	})
 }


### PR DESCRIPTION
Process, is the backbone of several sequence processors:
 - MapFilter, which handles all Map* and Filter* operations
 - Flatten

It had the unfortunate behaviour of allocating a new closure, and it's variables on the heap for each iteration, causing decent memory churn, halving the speed of some test programs with otherwise very simple loop bodies. Fixed it by moving the creation of the closure to once-per loop, and made it update and load it's state atomically via an atomic.Value. This was trickier, but now there are no heap allocations in the loop of any measure.

Added a Filter benchmark to see performance drop an allocations compared to NumberSequence (which has no allocs).