### PR TITLE
refactor: manually implement filter for speed

### DIFF
--- a/mapfilter.go
+++ b/mapfilter.go
@@ -44,7 +44,15 @@ func MapErr[In, Out any](s Sequence[In], convert func(In) (Out, error)) Sequence
 // that pass the provided predicate function will be emitted. The ouput
 // sequence will be the same type as the input sequence.
 func Filter[T any](s Sequence[T], pred func(T) bool) Sequence[T] {
-	return MapFilter(s, func(t T) (T, bool, error) { return t, pred(t), nil })
+	return Derive[T](s, func(f func(T) error) error {
+		return s.Each(func(t T) error {
+			if pred(t) {
+				return f(t)
+			}
+			return nil
+		})
+	})
+	// return MapFilter(s, func(t T) (T, bool, error) { return t, pred(t), nil })
 }
 
 // FilterErr takes an input sequence and creates a sequence where only the


### PR DESCRIPTION
Filter was implemented w.r.t. MapFilter, and although fairly decent, could have been better.

By manually implementing, our trivial benchmark now only does a single allocation (down from 3) and more importantly, is also 3x faster.

```
goos: linux
goarch: amd64
pkg: github.com/cookieo9/sequence
cpu: 11th Gen Intel(R) Core(TM) i3-1115G4 @ 3.00GHz

                  │   old.txt   │               new.txt                │
                  │   sec/op    │    sec/op     vs base                │
Filter/NoFilter-4   1.014m ± 1%   1.033m ±  2%   +1.87% (p=0.005 n=10)
Filter/Filter-4     8.616m ± 2%   2.960m ± 10%  -65.65% (p=0.000 n=10)
geomean             2.956m        1.749m        -40.85%

                  │   old.txt    │               new.txt                │
                  │     B/op     │    B/op     vs base                  │
Filter/NoFilter-4   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Filter/Filter-4     96.00 ± 0%     32.00 ± 0%  -66.67% (p=0.000 n=10)
geomean                        ²               -42.26%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                  │   old.txt    │               new.txt                │
                  │  allocs/op   │ allocs/op   vs base                  │
Filter/NoFilter-4   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Filter/Filter-4     3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.000 n=10)
geomean                        ²               -42.26%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```