### PR TITLE
refactor(perf): implement MapFilter manually

### DIFF
--- a/mapfilter.go
+++ b/mapfilter.go
@@ -7,12 +7,17 @@ package sequence
 // MapFilter allows the callback to stop iteration with a generic error, or use
 // ErrStopIteration to simply indicate that no more values should be proceed.
 func MapFilter[In, Out any](s Sequence[In], convert func(In) (Out, bool, error)) Sequence[Out] {
-	return Process[In, Out](s, func(i In, f func(Out)) error {
-		out, ok, err := convert(i)
-		if ok && err == nil {
-			f(out)
-		}
-		return err
+	return Derive(s, func(f func(Out) error) error {
+		return s.Each(func(i In) error {
+			out, ok, err := convert(i)
+			if err != nil {
+				return err
+			}
+			if ok {
+				return f(out)
+			}
+			return nil
+		})
 	})
 }
 


### PR DESCRIPTION
By implementing MapFilter using Derive, instead of piggybacking off of Process, we get a decent speed increase at both a single-item and per-loop level.

MapErr and Map use MapFilter and get similar, if slightly smaller improvements due to the extra level of indirection, but implementing each using Derive might get them slightly faster, but not as much as this step.

---------
```
goos: linux
goarch: amd64
pkg: github.com/cookieo9/sequence
cpu: 11th Gen Intel(R) Core(TM) i3-1115G4 @ 3.00GHz
                      │   old.txt    │               new.txt               │
                      │    sec/op    │   sec/op     vs base                │
Map/RawSingle-4          1.266n ± 2%   1.268n ± 2%        ~ (p=0.670 n=10)
Map/MapFilterSingle-4    7.253n ± 2%   3.017n ± 2%  -58.41% (p=0.000 n=10)
Map/MapErrSingle-4       8.887n ± 2%   3.860n ± 2%  -56.57% (p=0.000 n=10)
Map/MapSingle-4         10.125n ± 9%   4.088n ± 1%  -59.63% (p=0.000 n=10)
Map/Raw-4                1.339m ± 4%   1.274m ± 1%   -4.81% (p=0.000 n=10)
Map/MapFilter-4          7.944m ± 4%   3.114m ± 2%  -60.80% (p=0.000 n=10)
Map/MapErr-4             8.924m ± 3%   3.987m ± 2%  -55.33% (p=0.000 n=10)
Map/Map-4                9.043m ± 1%   4.131m ± 3%  -54.33% (p=0.000 n=10)
geomean                  5.387µ        2.815µ       -47.74%

                      │   old.txt    │               new.txt                │
                      │     B/op     │    B/op     vs base                  │
Map/RawSingle-4         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapFilterSingle-4   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapErrSingle-4      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapSingle-4         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/Raw-4               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapFilter-4         96.00 ± 0%     32.00 ± 0%  -66.67% (p=0.000 n=10)
Map/MapErr-4            96.00 ± 0%     32.00 ± 0%  -66.67% (p=0.000 n=10)
Map/Map-4               96.00 ± 0%     32.00 ± 0%  -66.67% (p=0.000 n=10)
geomean                            ²               -33.77%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                      │   old.txt    │               new.txt                │
                      │  allocs/op   │ allocs/op   vs base                  │
Map/RawSingle-4         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapFilterSingle-4   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapErrSingle-4      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapSingle-4         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/Raw-4               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Map/MapFilter-4         3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.000 n=10)
Map/MapErr-4            3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.000 n=10)
Map/Map-4               3.000 ± 0%     1.000 ± 0%  -66.67% (p=0.000 n=10)
geomean                            ²               -33.77%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```