### PR TITLE
feat: add Simulate

### DIFF
--- a/simulate.go
+++ b/simulate.go
@@ -1,0 +1,19 @@
+package sequence
+
+// Simulate creates a sequence where an initial state is updated by a function
+// that produces a new state, and indicates if there is more work to be done.
+// The sequence of states is expected to be deterministic given the initial
+// state and the step function, if not, the sequence should be marked volatile.
+// The output sequence returns the series of states created from the initial
+// state to the final state.
+func Simulate[T any](initial T, step func(T) (T, bool)) Sequence[T] {
+	return Generate(func(f func(T) error) error {
+		state := initial
+		for more := true; more; state, more = step(state) {
+			if err := f(state); err != nil {
+				return nil
+			}
+		}
+		return nil
+	})
+}

--- a/simulate_test.go
+++ b/simulate_test.go
@@ -1,0 +1,37 @@
+package sequence
+
+import (
+	"testing"
+
+	"github.com/cookieo9/sequence/tools"
+)
+
+func TestSimulate(t *testing.T) {
+	seq := Simulate(2, func(i int) (int, bool) {
+		i *= i
+		return i, i < 1_000_000
+	})
+	want := New(2, 4, 16, 256, 65536)
+
+	compareSequences(t, seq, want)
+}
+
+func BenchmarkSimulate(b *testing.B) {
+	seq := Simulate(2, func(i int) (int, bool) {
+		i *= i
+		return i, i < 1_000_000
+	})
+
+	b.Run("Raw", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = tools.Must(seq.Last())
+		}
+	})
+
+	mSeq := seq.Materialize()
+	b.Run("Materialized", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = tools.Must(mSeq.Last())
+		}
+	})
+}


### PR DESCRIPTION
Simulate is a sequence generator for a state-machine like object.

Start in an initial state, step through processing, returning new states until reaching the end.

The sequence of states is the history of the computation, .Last() provides the final resulting state.