### PR TITLE
refactor: make Repeat not use Limit

### DIFF
--- a/single.go
+++ b/single.go
@@ -21,7 +21,14 @@ func Infinite[T any](t T) Sequence[T] {
 // Repeat generates a sequence where the given item is returns a fixed number
 // of times.
 func Repeat[T any](t T, n int) Sequence[T] {
-	return Limit(Infinite(t), n)
+	return Generate(func(f func(T) error) error {
+		for i := 0; i < n; i++ {
+			if err := f(t); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // Single returns a sequence where the given value is returned once.


### PR DESCRIPTION
Repeat was previously a Limit() on Infinite(), which was fine, but had two issues:
 - Slower, as we're adding a level of compute/indirection
 - Requires ErrStopIteration, which is a little buggy at the moment

Using Repeat(t,1) to implement Single is fine, as we're not adding a level, and inlining should apply to limit overhead, but the buggy end-condition will cause problems.

The bug with ErrStopIteration is that there is no distinction between the case where a sequence is intentionally cut short by a wrapper that is creating a new sequence, and the "Stop, I'm done" calls made inside Each's callback to break out early. The former should not propogate to upper levels while the latter should.