### PR TITLE
Add Result type for converting from sequences

### DIFF
--- a/counting.go
+++ b/counting.go
@@ -39,13 +39,18 @@ func NumberSequence[T tools.Integer | tools.Real](start, stop, step T) Sequence[
 	})
 }
 
-// Count returns the number of items in the given sequence, and an error if any
-// are produced while iterating the sequence.
-func Count[T any](s Sequence[T]) (int, error) {
+// Count returns a Result with the number of items in the given sequence,
+// or an error if one was produced while iterating the sequence.
+func Count[T any](s Sequence[T]) Result[int] {
 	var n int
 	err := EachSimple(s)(func(t T) bool {
 		n++
 		return true
 	})
-	return n, err
+	return MakeResult(n, err)
+}
+
+// Count is a helper to call the package function [Count] on the receiver.
+func (s Sequence[T]) Count() Result[int] {
+	return Count(s)
 }

--- a/counting_test.go
+++ b/counting_test.go
@@ -18,25 +18,25 @@ func TestCounting(t *testing.T) {
 
 	compareSequences(t, limited, numSeq)
 
-	first := tools.Must(First(numSeq))
+	first := First(numSeq).Value()
 	wantFirst := 5
 	if first != wantFirst {
 		t.Errorf("unexpected difference for First(); got: %v, want: %v", first, wantFirst)
 	}
 
-	last := tools.Must(Last(numSeq))
+	last := Last(numSeq).Value()
 	wantLast := 1_000_004
 	if last != wantLast {
 		t.Errorf("unexpected difference for Last(); got: %v, want: %v", last, wantLast)
 	}
 
-	count := tools.Must(Count(numSeq))
+	count := Count(numSeq).Value()
 	wantCount := 1_000_000
 	if count != wantCount {
 		t.Errorf("unexpected difference for Count(); got: %v, want: %v", count, wantCount)
 	}
 
-	sum := tools.Must(Sum(numSeq))
+	sum := Sum(numSeq).Value()
 	wantSum := euler(5, 1_000_004)
 	if sum != wantSum {
 		t.Errorf("unexpected difference for Sum(); got: %v, want: %v", sum, wantSum)
@@ -53,14 +53,14 @@ func TestBadNumberSequences(t *testing.T) {
 	compareSequences(t, empty, New[int]())
 
 	inf := NumberSequence(0, 10, 0)
-	sum, err := Sum(inf)
+	sum, err := Sum(inf).Pair()
 	t.Logf("Sum(inf): %v %v", sum, err)
 	if err == nil {
 		t.Error("expected error, but none provided from Sum(inf)")
 	}
 
 	rev := NumberSequence(10, 0, -1)
-	sum, err = Sum(rev)
+	sum, err = Sum(rev).Pair()
 	t.Logf("Sum(rev): %v %v", sum, err)
 	if err == nil {
 		t.Error("expected error, but none provided from Sum(rev)")

--- a/extra/lines_test.go
+++ b/extra/lines_test.go
@@ -22,12 +22,11 @@ func quickFunc(gen func(io.Reader) sequence.Sequence[string]) func([]string) (st
 		full := strings.Join(s, "\n")
 		seq := gen(strings.NewReader(full))
 		num := 0
-		result, err := sequence.Collect(seq, "", func(line, merged string) string {
+		result := sequence.Collect(seq, "", func(line, merged string) string {
 			num++
 			return merged + line
 		})
-		tools.Check(err)
-		return result, num
+		return result.Value(), num
 	}
 }
 

--- a/maps.go
+++ b/maps.go
@@ -1,7 +1,5 @@
 package sequence
 
-import "github.com/cookieo9/sequence/tools"
-
 // FromMap creates a sequence of pairs, where the first item in the pair is a
 // key from the map, and the second item is the value for that key.
 // The sequence is Volatile, since multiple iterations could produce different
@@ -29,12 +27,13 @@ func IntoMap[M ~map[K]V, K comparable, V any](dst M, s Sequence[Pair[K, V]]) err
 	})
 }
 
-// ToMap creates a map from the given sequence of Pairs. The first element in
-// each pair must be comparable, since it must become a map key. An error
-// during processing will return a nil map in addition to the error. If you
-// wish to get a partially complete map on error, use [IntoMap].
-func ToMap[K comparable, V any](s Sequence[Pair[K, V]]) (map[K]V, error) {
+// ToMap creates a map from the given sequence of Pairs, and returning it in a
+// Result. The first element in each pair must be comparable, since it must
+// become a map key. Earlier items with the same key will be replaced by later
+// items in the sequence. If an error occurs, the value of the Result will
+// contain all the items processed so far.
+func ToMap[K comparable, V any](s Sequence[Pair[K, V]]) Result[map[K]V] {
 	m := map[K]V{}
 	err := IntoMap(m, s)
-	return tools.CleanErrors(m, err)
+	return MakeResult(m, err)
 }

--- a/result.go
+++ b/result.go
@@ -1,0 +1,80 @@
+package sequence
+
+// A Result represents a (Value,error) tuple where both could be present. It
+// will panic if the value is accessed alone when the error is non-nil.
+type Result[T any] struct {
+	value T
+	err   error
+}
+
+// Pair returns both the value stored and error (if any). It does not panic.
+func (r Result[T]) Pair() (T, error) {
+	return r.value, r.err
+}
+
+// Error returns the error stored in this result (if any) or nil.
+func (r Result[T]) Error() error {
+	return r.err
+}
+
+// HasError returns true if there's an error present in this Result.
+func (r Result[T]) HasError() bool {
+	return r.err != nil
+}
+
+// Value returns the value stored in this result (if any). If there is an error
+// stored in the result, this method will panic, otherwise the value is
+// returned or a zero value if none was stored.
+func (r Result[T]) Value() T {
+	if r.HasError() {
+		panic(r.err)
+	}
+	return r.value
+}
+
+// DropError returns a new result copied from the current result, with the
+// error explicity set to nil. This should only be used if the error can safely
+// be ignored or has already been dealt with.
+func (r Result[T]) DropError() Result[T] {
+	r.err = nil
+	return r
+}
+
+// Clean returns a new result where the presence of an error means that the
+// value is the zero value.
+func (r Result[T]) Clean() Result[T] {
+	if r.HasError() {
+		r.value = *new(T)
+	}
+	return r
+}
+
+// ResultValue creates a result using just the provided value, assuming a nil
+// error.
+func ResultValue[T any](value T) Result[T] {
+	return MakeResult(value, nil)
+}
+
+// ResultError creates a result with just an error. One may need to pass a type
+// argument, since it's likely the generic type inference won't detect the
+// the needed value type of the Result.
+func ResultError[T any](err error) Result[T] {
+	return MakeResult(*new(T), err)
+}
+
+// MakeResult is the base constructor for a result where both the value and
+// error are specified. Useful for wrapping a (T,error) returning function.
+func MakeResult[T any](value T, err error) Result[T] {
+	return Result[T]{value: value, err: err}
+}
+
+// NextResult accepts a result, and a function that will process the value
+// stored within, to produce a new result value. If the input result has
+// an error, no work is done other than propogating the error to the output
+// result value.
+func NextResult[In, Out any](in Result[In], f func(In) (Out, error)) Result[Out] {
+	if in.HasError() {
+		return ResultError[Out](in.Error())
+	}
+	return MakeResult(f(in.Value()))
+}

--- a/scan_test.go
+++ b/scan_test.go
@@ -21,7 +21,7 @@ func TestScanAndSum(t *testing.T) {
 	}
 
 	sumWant := 15
-	sumGot, err := Sum(seq)
+	sumGot, err := Sum(seq).Pair()
 	if err != nil {
 		t.Errorf("unexpected error computing sum: %v", err)
 	}

--- a/simulate_test.go
+++ b/simulate_test.go
@@ -3,7 +3,6 @@ package sequence
 import (
 	"testing"
 
-	"github.com/cookieo9/sequence/tools"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -60,28 +59,28 @@ func BenchmarkSimulate(b *testing.B) {
 	seq := Simulation(start, sim)
 	b.Run("Simulation", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = tools.Must(seq.Last())
+			_ = seq.Last().Value()
 		}
 	})
 
 	seq2 := Single(start).Simulate(sim)
 	b.Run("Single+Simulate", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = tools.Must(seq2.Last())
+			_ = seq2.Last().Value()
 		}
 	})
 
 	mSeq := seq.Materialize()
 	b.Run("Simulation+Materialize", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = tools.Must(mSeq.Last())
+			_ = mSeq.Last().Value()
 		}
 	})
 
 	mSeq2 := seq2.Materialize()
 	b.Run("Single+Simulate+Materialize", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = tools.Must(mSeq2.Last())
+			_ = mSeq2.Last().Value()
 		}
 	})
 }

--- a/single.go
+++ b/single.go
@@ -51,13 +51,13 @@ func Error[T any](err error) Sequence[T] {
 //
 // The callback may return errors to stop processing, either to indicate
 // failure, or in the case of ErrStopIteration to simply end processing.
-func CollectErr[T, U any](s Sequence[T], initial U, process func(T, U) (U, error)) (U, error) {
+func CollectErr[T, U any](s Sequence[T], initial U, process func(T, U) (U, error)) Result[U] {
 	err := Each(s.Sync())(func(t T) error {
 		var err error
 		initial, err = process(t, initial)
 		return err
 	})
-	return initial, err
+	return MakeResult(initial, err)
 }
 
 // Collect produces a single value from a sequence. It starts with an initial
@@ -65,56 +65,55 @@ func CollectErr[T, U any](s Sequence[T], initial U, process func(T, U) (U, error
 // the process function using the item from the sequence and the current value.
 // Collect uses [Sync] to synchronize updating the accumulated value, but the
 // order of updates is non-deterministic.
-func Collect[T, U any](s Sequence[T], initial U, process func(T, U) U) (U, error) {
+func Collect[T, U any](s Sequence[T], initial U, process func(T, U) U) Result[U] {
 	return CollectErr[T, U](s, initial, func(t T, u U) (U, error) {
 		return process(t, u), nil
 	})
 }
 
-// First returns the first value from the given sequence, or an error if even
-// that isn't possible. The results of first are not deterministic for an
-// asynchronous sequence.
-func First[T any](s Sequence[T]) (T, error) {
+// First returns a Result containing the first value from the given sequence,
+// or an error if even that isn't possible. The results of first are not
+// deterministic for an asynchronous sequence.
+func First[T any](s Sequence[T]) Result[T] {
 	var value T
 	err := EachSimple(s.Sync())(func(t T) bool { value = t; return false })
-	return tools.CleanErrors(value, err)
+	return MakeResult(value, err)
 }
 
-// Last returns the final value from the given sequence and any error should
-// the sequence end with an error. Unlike most functions both value and error
-// will be returns as it's really upto the caller to determine if an error
-// should stop downstream processing in this case. Note: ErrStopIteration
-// will still be suppressed as normal as it indicates early exit without error.
-func Last[T any](s Sequence[T]) (T, error) {
+// Last returns a Result containing the final value from the given sequence
+// and any error should the sequence end with an error.
+func Last[T any](s Sequence[T]) Result[T] {
 	var value T
 	err := EachSimple(s.Sync())(func(t T) bool { value = t; return true })
-	return value, err
+	return MakeResult(value, err)
 }
 
 // First is a helper method for the top level function [First].
-func (s Sequence[T]) First() (T, error) {
+func (s Sequence[T]) First() Result[T] {
 	return First(s)
 }
 
 // Last is a helper method for the top level function [Last].
-func (s Sequence[T]) Last() (T, error) {
+func (s Sequence[T]) Last() Result[T] {
 	return Last(s)
 }
 
 // Sum is a helper function for a sequence of arithmetic values that produces
 // the sum of the entire sequence.
-func Sum[T tools.Arithmetic](s Sequence[T]) (T, error) {
+func Sum[T tools.Arithmetic](s Sequence[T]) Result[T] {
 	return Collect(s, T(0), tools.Add)
 }
 
 // Product is a helper function for a sequence of arithmetic values that
 // returns the product of all values in the sequence.
-func Product[T tools.Arithmetic](s Sequence[T]) (T, error) {
+func Product[T tools.Arithmetic](s Sequence[T]) Result[T] {
 	return Collect(s, T(1), tools.Mul)
 }
 
-// Max returns the smallest item from the sequence of cmp.Ordered items.
-func Max[T cmp.Ordered](s Sequence[T]) (T, error) {
+// Max returns a Result containing the smallest item from the sequence of
+// cmp.Ordered items. The result will contain only an error if one stopped
+// processing early.
+func Max[T cmp.Ordered](s Sequence[T]) Result[T] {
 	var (
 		empty    = true
 		maxValue T
@@ -129,13 +128,14 @@ func Max[T cmp.Ordered](s Sequence[T]) (T, error) {
 		return true
 	})
 	err = tools.Pick(err == nil && empty, ErrEmptySequence, err)
-	return tools.CleanErrors(maxValue, err)
+	return MakeResult(maxValue, err).Clean()
 }
 
 // MaxFunc returns the largest item from the sequence as determined by the
 // provided comparision function. The comparison must return true if
-// the first value is strictly less than the second.
-func MaxFunc[T any](s Sequence[T], less func(x, y T) bool) (T, error) {
+// the first value is strictly less than the second. The returned result like
+// with [Max], will only contain the error if one occurred.
+func MaxFunc[T any](s Sequence[T], less func(x, y T) bool) Result[T] {
 	var (
 		empty    = true
 		maxValue T
@@ -150,11 +150,13 @@ func MaxFunc[T any](s Sequence[T], less func(x, y T) bool) (T, error) {
 		return true
 	})
 	err = tools.Pick(err == nil && empty, ErrEmptySequence, err)
-	return tools.CleanErrors(maxValue, err)
+	return MakeResult(maxValue, err).Clean()
 }
 
-// Min returns the smallest item from the sequence of cmp.Ordered items.
-func Min[T cmp.Ordered](s Sequence[T]) (T, error) {
+// Min returns a Result containing the smallest item from the sequence of
+// cmp.Ordered items. Any error during processing will stop the collection
+// early, and the Result generate will only contain the error.
+func Min[T cmp.Ordered](s Sequence[T]) Result[T] {
 	var (
 		empty    = true
 		minValue T
@@ -169,13 +171,14 @@ func Min[T cmp.Ordered](s Sequence[T]) (T, error) {
 		return true
 	})
 	err = tools.Pick(err == nil && empty, ErrEmptySequence, err)
-	return tools.CleanErrors(minValue, err)
+	return MakeResult(minValue, err).Clean()
 }
 
 // MinFunc returns the smallest item from the sequence as determined by the
 // provided comparision function. The comparison must return true if
-// the first value is strictly less than the second.
-func MinFunc[T any](s Sequence[T], less func(x, y T) bool) (T, error) {
+// the first value is strictly less than the second. Otherwise it returns a
+// Result with the same restrictions as [Min].
+func MinFunc[T any](s Sequence[T], less func(x, y T) bool) Result[T] {
 	var (
 		empty    = true
 		minValue T
@@ -190,5 +193,5 @@ func MinFunc[T any](s Sequence[T], less func(x, y T) bool) (T, error) {
 		return true
 	})
 	err = tools.Pick(err == nil && empty, ErrEmptySequence, err)
-	return tools.CleanErrors(minValue, err)
+	return MakeResult(minValue, err).Clean()
 }

--- a/single_test.go
+++ b/single_test.go
@@ -27,7 +27,7 @@ func TestMinMax(t *testing.T) {
 			wantMax := tc.max
 			less := func(x, y int) bool { return x < y }
 
-			minFunc, err := MinFunc(Volatile(seq), less)
+			minFunc, err := MinFunc(Volatile(seq), less).Pair()
 			if err != tc.err {
 				t.Errorf("unexpected error difference for MinFunc; got %v, want %v", err, tc.err)
 			}
@@ -35,7 +35,7 @@ func TestMinMax(t *testing.T) {
 				t.Errorf("unexpected difference for MinFunc; got %v, want %v", minFunc, wantMin)
 			}
 
-			minCmp, err := Min(Volatile(seq))
+			minCmp, err := Min(Volatile(seq)).Pair()
 			if err != tc.err {
 				t.Errorf("unexpected error difference for Min; got %v, want %v", err, tc.err)
 			}
@@ -43,7 +43,7 @@ func TestMinMax(t *testing.T) {
 				t.Errorf("unexpected difference for Min; got %v, want %v", minCmp, wantMin)
 			}
 
-			maxFunc, err := MaxFunc(Volatile(seq), less)
+			maxFunc, err := MaxFunc(Volatile(seq), less).Pair()
 			if err != tc.err {
 				t.Errorf("unexpected error difference for MaxFunc; got %v, want %v", err, tc.err)
 			}
@@ -51,7 +51,7 @@ func TestMinMax(t *testing.T) {
 				t.Errorf("unexpected difference for MaxFunc; got %v, want %v", maxFunc, wantMax)
 			}
 
-			maxCmp, err := Max(Volatile(seq))
+			maxCmp, err := Max(Volatile(seq)).Pair()
 			if err != tc.err {
 				t.Errorf("unexpected error difference for Max; got %v, want %v", err, tc.err)
 			}


### PR DESCRIPTION
When we convert from a sequence to a regular go value there is always a possible error. Instead of having people rely on tools.Must, or check everything themselves, wrap such values in a new Result[T] type which is a tuple of the result and the error.

This provides a few benefits:
 - Calling the .Value() method will return the value easily, or panic if there was an unhandled error, like with tools.Must
 - Calling the .DropError() method will return a Result with no error, if it can be easily ignored, and thus make a following .Value() always succeed.
 - Calling .Pair() returns the (T,error) we want if were doing normal go error handling.
 - Calling .Clean() returns a result where the value is zeroed if the error was non-nil, like with tools.CleanErrors(), should the value never be used when an error was also present.