### PR TITLE
refactor(slices): use Result with ToSlice/Append

### DIFF
--- a/concat_test.go
+++ b/concat_test.go
@@ -12,7 +12,7 @@ func TestConcat(t *testing.T) {
 	b := Repeat(4, 3)
 	ab := a.Concat(b)
 	want := []int{1, 2, 3, 4, 4, 4}
-	got, err := ab.ToSlice()
+	got, err := ab.ToSlice().Pair()
 	if err != nil {
 		t.Errorf("unexpected error upon conversion to slice: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestConcat(t *testing.T) {
 	wantErr := errors.New("my wonderful error")
 	eSeq := Error[int](wantErr)
 	aeb := Concat(a, eSeq, b)
-	result, err := ToSlice(aeb)
+	result, err := ToSlice(aeb).Pair()
 	if err != wantErr {
 		t.Errorf("error mismatch, got %v, want %v", err, wantErr)
 	}
@@ -36,7 +36,7 @@ func TestFlatten(t *testing.T) {
 	seq := New([]int{1, 2, 3}, []int{6, 5, 4})
 	flat := Flatten(seq).Limit(5)
 	want := []int{1, 2, 3, 6, 5}
-	got, err := flat.ToSlice()
+	got, err := flat.ToSlice().Pair()
 	if err != nil {
 		t.Errorf("unexpected error upon conversion to slice: %v", err)
 	}

--- a/materialize.go
+++ b/materialize.go
@@ -18,7 +18,7 @@ import "sync"
 // asynchronous input will mean the values stored for playback will be in a
 // non-deterministic order.
 func Materialize[T any](s Sequence[T]) Sequence[T] {
-	data, srcErr := ToSlice(s.Sync())
+	data, srcErr := ToSlice(s.Sync()).Pair()
 	return Generate[T](func(f func(T) error) error {
 		for _, x := range data {
 			if err := f(x); err != nil {

--- a/scan_test.go
+++ b/scan_test.go
@@ -12,7 +12,7 @@ func TestScanAndSum(t *testing.T) {
 	scn := seq.Scan(1, tools.Mul[int])
 
 	scnWant := []int{1, 2, 6, 24, 120}
-	scnGot, err := scn.ToSlice()
+	scnGot, err := scn.ToSlice().Pair()
 	if err != nil {
 		t.Errorf("unexpected error converting scan to slice: %v", err)
 	}

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -9,7 +9,7 @@ import (
 func TestSequence(t *testing.T) {
 	input := []int{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5}
 	s := FromSlice(input)
-	full, err := s.ToSlice()
+	full, err := s.ToSlice().Pair()
 	if err != nil {
 		t.Errorf("unexpected error in copy: %v", err)
 	} else if diff := cmp.Diff(full, input); diff != "" {
@@ -18,14 +18,14 @@ func TestSequence(t *testing.T) {
 
 	l := Limit(s, 5)
 	want := []int{3, 1, 4, 1, 5}
-	got, err := l.ToSlice()
+	got, err := l.ToSlice().Pair()
 	if err != nil {
 		t.Errorf("unexpected error in limited copy: %v", err)
 	} else if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("unexpected diff in limited copy (-got, +want): \n%s", diff)
 	}
 
-	if full, err = s.ToSlice(); err != nil {
+	if full, err = s.ToSlice().Pair(); err != nil {
 		t.Errorf("unexpected error in second copy: %v", err)
 	} else if diff := cmp.Diff(full, input); diff != "" {
 		t.Errorf("unexpected diff in copy copy (-got, +want): \n%s", diff)

--- a/slices.go
+++ b/slices.go
@@ -1,27 +1,25 @@
 package sequence
 
-import "github.com/cookieo9/sequence/tools"
-
 // ToSlice is a utility method that calls the top level function version of
 // [ToSlice].
-func (s Sequence[T]) ToSlice() ([]T, error) {
+func (s Sequence[T]) ToSlice() Result[[]T] {
 	return ToSlice(s)
 }
 
 // Append processes the given sequence such that each item returned is
 // appended to the provided destination slice. The resulting final
 // slice is returned.
-func Append[S ~[]T, T any](dst S, s Sequence[T]) (S, error) {
+func Append[S ~[]T, T any](dst S, s Sequence[T]) Result[S] {
 	err := EachSimple(s.Sync())(func(t T) bool {
 		dst = append(dst, t)
 		return true
 	})
-	return tools.CleanErrors(dst, err)
+	return MakeResult(dst, err).Clean()
 }
 
 // ToSlice returns a new slice containing every item received from the given
 // sequence, or any error that occured while doing so.
-func ToSlice[T any](s Sequence[T]) ([]T, error) {
+func ToSlice[T any](s Sequence[T]) Result[[]T] {
 	return Append([]T(nil), s)
 }
 

--- a/sort.go
+++ b/sort.go
@@ -11,7 +11,7 @@ import (
 // Note: This function must read and store the entire sequence prior to sorting
 // it, which may be an issue for large/infinite sequences.
 func SortOrdered[T cmp.Ordered](s Sequence[T]) Sequence[T] {
-	data, err := s.ToSlice()
+	data, err := s.ToSlice().Pair()
 	if err != nil {
 		return Error[T](err)
 	}
@@ -27,7 +27,7 @@ func SortOrdered[T cmp.Ordered](s Sequence[T]) Sequence[T] {
 // Note: This function must read and store the entire sequence prior to sorting
 // it, which may be an issue for large/infinite sequences.
 func Sort[T any](s Sequence[T], cmp func(a, b T) int) Sequence[T] {
-	data, err := s.ToSlice()
+	data, err := s.ToSlice().Pair()
 	if err != nil {
 		return Error[T](err)
 	}
@@ -46,7 +46,7 @@ func (s Sequence[T]) Sort(cmp func(T, T) int) Sequence[T] {
 // Note: This function must read and store the entire sequence prior to sorting
 // it, which may be an issue for large/infinite sequences.
 func SortStable[T any](s Sequence[T], cmp func(a, b T) int) Sequence[T] {
-	data, err := s.ToSlice()
+	data, err := s.ToSlice().Pair()
 	if err != nil {
 		return Error[T](err)
 	}
@@ -66,7 +66,7 @@ func (s Sequence[T]) SortStable(cmp func(T, T) int) Sequence[T] {
 // Note: This function must read and store the entire sequence prior to
 // reversing it, which may be an issue for large/infinite sequences.
 func Reverse[T any](s Sequence[T]) Sequence[T] {
-	data, err := s.ToSlice()
+	data, err := s.ToSlice().Pair()
 	if err != nil {
 		return Error[T](err)
 	}

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -43,13 +43,13 @@ func (s *Set[T]) AddMany(xs ...T) {
 func compareSequences[T comparable](tb testing.TB, got, want Sequence[T], opts ...cmp.Option) {
 	tb.Helper()
 
-	gotSlice, err := ToSlice(got)
+	gotSlice, err := ToSlice(got).Pair()
 	if err != nil {
 		tb.Errorf("problem converting got sequence to slice: %v", err)
 	}
 	tb.Logf("Got: %v (err: %v)", gotSlice, err)
 
-	wantSlice, err := ToSlice[T](want)
+	wantSlice, err := ToSlice[T](want).Pair()
 	if err != nil {
 		tb.Errorf("problem converting want sequence to slice: %v", err)
 	}

--- a/zip_test.go
+++ b/zip_test.go
@@ -3,7 +3,6 @@ package sequence
 import (
 	"testing"
 
-	"github.com/cookieo9/sequence/tools"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -15,7 +14,7 @@ func TestZip(t *testing.T) {
 	opt := cmpopts.EquateComparable(Pair[int, string]{})
 
 	short := Zip(seq1, seq2)
-	gotShort := tools.Must(short.ToSlice())
+	gotShort := short.ToSlice().Value()
 	wantShort := []Pair[int, string]{{1, "one"}, {2, "two"}, {3, "three"}}
 
 	if diff := cmp.Diff(gotShort, wantShort, opt); diff != "" {
@@ -23,7 +22,7 @@ func TestZip(t *testing.T) {
 	}
 
 	long := ZipLongest(seq1, seq2)
-	gotLong := tools.Must(long.ToSlice())
+	gotLong := long.ToSlice().Value()
 	wantLong := []Pair[int, string]{{1, "one"}, {2, "two"}, {3, "three"}, {4, ""}}
 
 	if diff := cmp.Diff(gotLong, wantLong, opt); diff != "" {


### PR DESCRIPTION
Missed this with the first Result refactor, but change ToSlice/Append functions to return a Result of their generated slice.

Places where they were previously using tools.Must can now use .Value(), and places where they cared about the error now use Pair().

Currently still an "all-or-nothing" result from both ToSlice(), and Append(), but may want to revisit that later.