### PR TITLE
test: add Limit test for infinite sequences

### DIFF
--- a/limit_test.go
+++ b/limit_test.go
@@ -19,3 +19,13 @@ func TestUntil(t *testing.T) {
 
 	compareSequences(t, got, want)
 }
+
+func TestLimit(t *testing.T) {
+	c := Counter(0).
+		Filter(func(i int) bool { return i&1 == 1 }).
+		Limit(10)
+	want := NumberSequence(1, 1_000_000_000_000, 2).
+		Limit(10)
+
+	compareSequences(t, c, want)
+}


### PR DESCRIPTION
I was a little worried that infinite sequences weren't being handled correctly by Limit, and were being allowed to do all their (infinite) work.

So I added a test for that, although it might not cover all cases, as the wrapper might affect how well it works.